### PR TITLE
Drop Python 2.7 and Django 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ language: python
 dist: xenial
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
-  - pypy2.7-6.0
   - pypy3.5-6.0
 
 

--- a/sendfile/__init__.py
+++ b/sendfile/__init__.py
@@ -6,9 +6,8 @@ import unicodedata
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.http import urlquote
-import six
 
 from ._version import get_versions
 
@@ -87,12 +86,9 @@ def sendfile(request, filename, attachment=False, attachment_filename=None,
         attachment_filename = os.path.basename(filename)
 
     if attachment_filename:
-        attachment_filename = force_text(attachment_filename)
+        attachment_filename = force_str(attachment_filename)
         ascii_filename = unicodedata.normalize('NFKD', attachment_filename)
-        ascii_filename = ascii_filename.encode('ascii', 'ignore')
-
-        if six.PY3:
-            ascii_filename = ascii_filename.decode()
+        ascii_filename = ascii_filename.encode('ascii', 'ignore').decode()
         parts.append('filename="%s"' % ascii_filename)
 
         if ascii_filename != attachment_filename:

--- a/sendfile/backends/_internalredirect.py
+++ b/sendfile/backends/_internalredirect.py
@@ -1,12 +1,7 @@
+from urllib.parse import quote
 import os.path
 
 from django.conf import settings
-from django.utils.encoding import smart_text, smart_bytes
-
-try:
-    from urllib.parse import quote
-except ImportError:
-    from urllib import quote
 
 
 def _convert_file_to_url(filename):
@@ -18,8 +13,4 @@ def _convert_file_to_url(filename):
         relpath, head = os.path.split(relpath)
         url.insert(1, head)
 
-    # Python3 urllib.parse.quote accepts both unicode and bytes, while Python2
-    # urllib.quote only accepts bytes.  So use bytes for quoting and then go
-    # back to unicode.
-    url = [smart_bytes(url_component) for url_component in url]
-    return smart_text(quote(b'/'.join(url)))
+    return quote('/'.join(url))

--- a/sendfile/backends/simple.py
+++ b/sendfile/backends/simple.py
@@ -1,10 +1,7 @@
+from email.utils import parsedate_tz, mktime_tz
 import os
-import stat
 import re
-try:
-    from email.utils import parsedate_tz, mktime_tz
-except ImportError:
-    from email.Utils import parsedate_tz, mktime_tz
+import stat
 
 from django.core.files.base import File
 from django.http import HttpResponse, HttpResponseNotModified

--- a/sendfile/backends/xsendfile.py
+++ b/sendfile/backends/xsendfile.py
@@ -1,12 +1,8 @@
 from django.http import HttpResponse
-import six
 
 
 def sendfile(request, filename, **kwargs):
-    filename = six.text_type(filename)
-    if six.PY2:
-        filename = filename.encode("utf-8")
-
+    filename = str(filename)
     response = HttpResponse()
     response['X-Sendfile'] = filename
 

--- a/sendfile/tests.py
+++ b/sendfile/tests.py
@@ -1,18 +1,16 @@
 # coding=utf-8
 
-from django.conf import settings
-from django.test import TestCase
-from django.http import HttpResponse, Http404, HttpRequest
-from django.utils.encoding import smart_str
-import os.path
 from tempfile import mkdtemp
+from urllib.parse import unquote
+import os.path
 import shutil
-from sendfile import sendfile as real_sendfile, _get_sendfile
 
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from django.conf import settings
+from django.http import HttpResponse, Http404, HttpRequest
+from django.test import TestCase
+from django.utils.encoding import smart_str
+
+from sendfile import sendfile as real_sendfile, _get_sendfile
 
 
 def sendfile(request, filename, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/moggers87/django-sendfile2',
     license='BSD',
 
-    install_requires=['django', 'six'],
+    install_requires=['django'],
     packages=['sendfile', 'sendfile.backends'],
     package_dir={
         'sendfile': 'sendfile',
@@ -35,8 +35,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     clean
-    py{py,27,py3,35,36,37}-django111
     py{py3,35,36,37,38}-django{21,22}
     flake8
     coverage
@@ -9,7 +8,6 @@ envlist =
 [testenv]
 usedevelop=True
 deps =
-    django111: Django>=1.11,<1.12
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     coverage


### PR DESCRIPTION
* Stop testing against Python 2.7 and Django 1.11
* Remove six
* Remove Python 2 from trove classifiers

Fixes #17