### PR TITLE
Fix minor spelling mistake. `ust` -> `must`

### DIFF
--- a/django_sendfile/sendfile.py
+++ b/django_sendfile/sendfile.py
@@ -15,7 +15,7 @@ from django.utils.http import urlquote
 def _get_sendfile():
     backend = getattr(settings, 'SENDFILE_BACKEND', None)
     if not backend:
-        raise ImproperlyConfigured('You ust specify a value for SENDFILE_BACKEND')
+        raise ImproperlyConfigured('You must specify a value for SENDFILE_BACKEND')
     module = import_module(backend)
     return module.sendfile
 


### PR DESCRIPTION
A really simple PR to resolve a spelling mistake. This PR could also be an opportunity to improve this error message in some meaningful way. Perhaps linking to docs described in #31, e.g.

```
SENDFILE_BACKEND not defined in Django settings. See https://... 
```