### PR TITLE
Avoid rewriting existing headers.

### DIFF
--- a/django_sendfile/utils.py
+++ b/django_sendfile/utils.py
@@ -73,12 +73,20 @@ def sendfile(request, filename, attachment=False, attachment_filename=None,
 
     response['Content-Disposition'] = '; '.join(parts)
 
-    response['Content-length'] = os.path.getsize(filename)
-    response['Content-Type'] = mimetype
+    # Avoid rewriting existing headers.
+    length_header = 'Content-Length'
+    if response.get(length_header) is None:
+        response[length_header] = os.path.getsize(filename)
+
+    mimetype_header = 'Content-Type'
+    if response.get(mimetype_header) is None:
+        response[mimetype_header] = mimetype
 
     if not encoding:
         encoding = guessed_encoding
-    if encoding:
-        response['Content-Encoding'] = encoding
+
+    content_header = 'Content-Encoding'
+    if encoding and not response.get(content_header) is None:
+        response[content_header] = encoding
 
     return response


### PR DESCRIPTION
My standard backend implements `Range Bytes` but the app was rewriting the `Content-Length` header and causing communication problems like the browser.

The correction prevents existing headers from being written unnecessarily.
```

def sendfile(request, fullpath, **kwargs):
    # Respect the If-Modified-Since header.
    statobj = os.stat(fullpath)
    if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
                              statobj.st_mtime, statobj.st_size):
        return HttpResponseNotModified()

    content_type, encoding = mimetypes.guess_type(fullpath)
    content_type = content_type or 'application/octet-stream'
    content_size = statobj.st_size

    content_range = HttpRange(request, content_size)
    if content_range:
        first_byte, last_byte, length = content_range.generate_bytes()
        response = StreamingHttpResponse(file_iterator(fullpath, offset=first_byte, length=length),
                                         status=206, content_type=content_type)
        response['Content-Length'] = str(length)
        response['Content-Range'] = 'bytes %s-%s/%s' % (first_byte, last_byte, content_size)
    else:
        response = MediaFileResponse(open(fullpath, 'rb'), content_type=content_type)
        response["Last-Modified"] = http_date(statobj.st_mtime)
        if stat.S_ISREG(statobj.st_mode):
            response["Content-Length"] = content_size
        if encoding:
            response["Content-Encoding"] = encoding
    return response
```