### PR TITLE
feat: support for filenames with spaces

### DIFF
--- a/django_sendfile/tests.py
+++ b/django_sendfile/tests.py
@@ -123,6 +123,15 @@ class TestSendfile(TempFileTestCase):
         self.assertEqual('attachment; filename="tests.txt"; filename*=UTF-8\'\'test%E2%80%99s.txt',
                          response['Content-Disposition'])
 
+    def test_attachment_filename_with_space(self):
+        response = real_sendfile(HttpRequest(), self._get_readme(), attachment=True,
+                                 attachment_filename='space test’s.txt')
+        self.assertTrue(response is not None)
+        self.assertEqual(
+            'attachment; filename="space tests.txt"; filename*=UTF-8\'\'space%20test%E2%80%99s.txt',
+            response['Content-Disposition']
+        )
+
 
 class TestSimpleSendfileBackend(TempFileTestCase):
 

--- a/django_sendfile/utils.py
+++ b/django_sendfile/utils.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from importlib import import_module
 from mimetypes import guess_type
 from pathlib import Path, PurePath
-from urllib.parse import quote, quote_plus
+from urllib.parse import quote
 import logging
 import unicodedata
 
@@ -112,7 +112,7 @@ def sendfile(request, filename, attachment=False, attachment_filename=None,
         parts.append('filename="%s"' % ascii_filename)
 
         if ascii_filename != attachment_filename:
-            quoted_filename = quote_plus(attachment_filename)
+            quoted_filename = quote(attachment_filename)
             parts.append('filename*=UTF-8\'\'%s' % quoted_filename)
 
     response['Content-Disposition'] = '; '.join(parts)


### PR DESCRIPTION
Hi Matt,

thanks for keeping this project alive!

I noticed that you switched from `urlquote` to `urlquote_plus` when dropping djangos `urlquote`.
For me this results in filenames with spaces like `test file.pdf` being downloaded as `test+file.pdf`.
I've switched to using just `quote` and it seems to work fine (at least in dev and with nginx).

What do you think about moving to `quote`? 